### PR TITLE
Add simple scaling

### DIFF
--- a/src/tiny_text.adb
+++ b/src/tiny_text.adb
@@ -9,12 +9,14 @@ package body Tiny_Text is
       (This   : in out Text_Buffer;
       Bitmap : Any_Bitmap_Buffer;
       Width  : Natural;
-      Height : Natural) is
+      Height : Natural;
+      Scale  : Positive := 1) is
    begin
       This.Width := Width;
       This.Height := Height;
       This.Bitmap := Bitmap;
       This.Default_Cursor := (0, 0);
+      This.Scale := Scale;
       This.Clear;
    end Initialize;
 
@@ -29,8 +31,8 @@ package body Tiny_Text is
    procedure New_Line (This : in out Text_Buffer) is
    begin
       This.Cursor.X := 0;
-      This.Cursor.Y := This.Cursor.Y + Font_Height + 1;
-      if (This.Cursor.Y + Font_Height) >= This.Height then
+      This.Cursor.Y := This.Cursor.Y + Font_Height + 1 + This.Scale / 2;
+      if (This.Cursor.Y + Font_Height) * This.Scale >= This.Height then
          This.Cursor.Y := 0;
          This.Clear;
       end if;
@@ -38,8 +40,8 @@ package body Tiny_Text is
 
    procedure Advance (This : in out Text_Buffer) is
    begin
-      This.Cursor.X := This.Cursor.X + Font_Width + 1;
-      if This.Cursor.X >= This.Width then
+      This.Cursor.X := This.Cursor.X + Font_Width + 1 + This.Scale / 2;
+      if (This.Cursor.X + Font_Width) * This.Scale >= This.Width then
          This.New_Line;
       end if;
    end Advance;
@@ -56,15 +58,16 @@ package body Tiny_Text is
    begin
       for X in 0 .. (Font_Width - 1) loop
          for Y in 0 .. (Font_Height - 1) loop
-            P.X := (Location.X + (Font_Width - X));
-            P.Y := (Location.Y + Y);
+            P.X := (Location.X + (Font_Width - X)) * This.Scale;
+            P.Y := (Location.Y + Y) * This.Scale;
             Pixel := Shift_Right
                (FC, (Font_Width * Font_Height) - (Y * 3) + X) and 1;
             if Pixel = 1 then
-               This.Bitmap.Set_Pixel (P, Foreground);
+               This.Bitmap.Set_Source (Foreground);
             else
-               This.Bitmap.Set_Pixel (P, Background);
+               This.Bitmap.Set_Source (Background);
             end if;
+            This.Bitmap.Fill_Rect (Rect'(P, This.Scale, This.Scale));
          end loop;
       end loop;
    end Put;

--- a/src/tiny_text.ads
+++ b/src/tiny_text.ads
@@ -118,13 +118,15 @@ package Tiny_Text is
       Cursor       : Point := (0, 0);
       Foreground    : Bitmap_Color := White;
       Background    : Bitmap_Color := Black;
+      Scale         : Positive := 1;
    end record;
 
    procedure Initialize
       (This   : in out Text_Buffer;
        Bitmap : Any_Bitmap_Buffer;
        Width  : Natural;
-       Height : Natural);
+       Height : Natural;
+       Scale  : Positive := 1);
 
    procedure Clear
       (This : in out Text_Buffer);


### PR DESCRIPTION
I added a simple scaling for smaller displays with higher resolutions. It simply increases the pixel size of the font and adjusts the cursor behavior accordingly. The space between characters and lines scales half as much as the characters themselves.

This is how it looks on a [ST7789](https://www.adafruit.com/product/3787) with `Scale = 3`.
![image](https://github.com/JeremyGrosser/tiny_text/assets/7999005/c91c789b-de40-44b2-bd41-4cba38c9861a)
